### PR TITLE
Fix order of flushing processor to be reversed

### DIFF
--- a/src/pkg/logs.go
+++ b/src/pkg/logs.go
@@ -72,7 +72,7 @@ func (s *LogStreamer) Flush(outcome JobOutcome) {
 	s.quit <- true
 	time.Sleep(200 * time.Millisecond) // Allow 'Run' goroutine to quit
 	s.logger.Trace().Msg("Flushing log processors ...")
-	for _, processor := range s.processors {
-		processor.Flush(outcome)
+	for i := len(s.processors)-1; i >= 0; i-- {
+		s.processors[i].Flush(outcome)
 	}
 }


### PR DESCRIPTION
The OutcomeVar processor used to be manually flushed after the job finished.  This is no longer the case but we still need it to be the case so we should flush the processors in reverse order.