### PR TITLE
Use API_URL not APP_URL

### DIFF
--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -61,7 +61,7 @@ func getGoInfo() GoInfo {
 
 func getOpslevelVersion() OpslevelVersion {
 	// Need to update all of this when we switch over to resty client
-	url, err := url.Parse(viper.GetString("app-url"))
+	url, err := url.Parse(viper.GetString("api-url"))
 	cobra.CheckErr(err)
 
 	url.Path = "/api/ping"


### PR DESCRIPTION
These parameters were merged in:
466e3ccdb7c5e89b891998633c3cdb75b4536451

After talking with Kyle Rockman, I also learned that the app, and api
subdomains were also merged so that their respective routes are
available at opslevel.com directly.

This is why we are able to perform graph queries and restful queries off
of the same base URL passed into the runner as --api_url