### PR TITLE
have sentry capture jobs with outcomes that are not successful

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -116,6 +116,13 @@ func jobWorker(index int, runnerId string, jobQueue <-chan opslevel.RunnerJob) {
 			err := errors.New(outcome.Message)
 			spanFinish.RecordError(err)
 			spanFinish.SetStatus(codes.Error, err.Error())
+
+			localHub := sentry.CurrentHub().Clone()
+			localHub.ConfigureScope(func(scope *sentry.Scope) {
+				scope.SetTag("outcome", string(outcome.Outcome))
+				scope.SetTag("job_id", job.Id.(string))
+			})
+			localHub.CaptureMessage(err.Error())
 		}
 		spanFinish.End()
 		spanStart.End()


### PR DESCRIPTION
This is so we can view these in sentry as thats better then the datadog monitor we have today.