### PR TITLE
Log errors to stdout

### DIFF
--- a/.changes/unreleased/Refactor-20221005-203636.yaml
+++ b/.changes/unreleased/Refactor-20221005-203636.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: Log error message when Sentry isn't configured
+time: 2022-10-05T20:36:36.541168-05:00

--- a/src/pkg/errors.go
+++ b/src/pkg/errors.go
@@ -2,12 +2,18 @@ package pkg
 
 import (
 	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 func CheckErr(err error) {
 	if err != nil {
-		sentry.CaptureException(err)
+		if _, present := os.LookupEnv("SENTRY_DSN"); present {
+			sentry.CaptureException(err)
+		} else {
+			log.Error().Err(err).Msg("")
+		}
 	}
 	cobra.CheckErr(err)
 }


### PR DESCRIPTION
Tested this locally and saw the error message in Stdout:  
```
1:32AM INF Starting job processor 1 ... worker=1
1:32AM INF Starting job processor 3 ... worker=3
1:32AM INF Starting job processor 2 ... worker=2
1:35AM INF Starting job '1745' worker=1
1:35AM WRN Job '1745' failed REASON: pod execution failed REASON: *****Start of Error Message*****
This is a multi-line test to log error in Sentry event!!!
Line 1
Line 2
Line 3
*****End of Error Message***** command terminated with exit code 128 worker=1
1:35AM INF Finished Job '1745' took '9.556611167s' and had outcome 'failed' worker=1
```