### PR TITLE
Eo/add leader election

### DIFF
--- a/.changes/unreleased/Feature-20221121-155234.yaml
+++ b/.changes/unreleased/Feature-20221121-155234.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Adding leader election to handle scaling
+time: 2022-11-21T15:52:34.542107-06:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -38,9 +38,10 @@ func init() {
 	rootCmd.PersistentFlags().String("log-level", "INFO", "overrides environment variable 'OPSLEVEL_LOG_LEVEL' (options [\"ERROR\", \"WARN\", \"INFO\", \"DEBUG\"])")
 	rootCmd.PersistentFlags().Bool("scaling-enabled", false, "Enables built-in pod scaling for kubernetes environment, defaults to false for local development")
 
+	// TODO: Update pod-* flags to job-pod-* to distinguish between job and runner specific values.  Moving this work over to separate ticket since it's a breaking change: https://gitlab.com/jklabsinc/OpsLevel/-/issues/5763
 	rootCmd.PersistentFlags().Int("pod-max-wait", 60, "The max amount of time to wait for the job pod to become healthy.")
 	rootCmd.PersistentFlags().Int("job-pod-max-lifetime", 3600, "The max amount of time a job pod can run for.")
-	rootCmd.PersistentFlags().String("pod-namespace", "default", "The kubernetes namespace to create pods in.")
+	rootCmd.PersistentFlags().String("pod-namespace", "default", "The kubernetes namespace to create job pods in.")
 	rootCmd.PersistentFlags().Int64("pod-requests-cpu", 1000, "Default is in millicores.")
 	rootCmd.PersistentFlags().Int64("pod-requests-memory", 1024, "Pod job resource requests in MB.")
 	rootCmd.PersistentFlags().Int64("pod-limits-cpu", 1000, "Default is in millicores.")
@@ -48,6 +49,9 @@ func init() {
 	rootCmd.PersistentFlags().String("pod-shell", "/bin/sh", "The shell to use for commands inside the pod.")
 	rootCmd.PersistentFlags().Int("pod-log-max-interval", 30, "The max amount of time between when pod logs are shipped to OpsLevel. Works in tandem with 'pod-log-max-size'")
 	rootCmd.PersistentFlags().Int("pod-log-max-size", 1000000, "The max amount in bytes to buffer before pod logs are shipped to OpsLevel. Works in tandem with 'pod-log-max-interval'")
+	rootCmd.PersistentFlags().String("runner-pod-name", "", "overrides environment variable 'RUNNER_POD_NAME'")
+	rootCmd.PersistentFlags().String("runner-pod-namespace", "default", "The kubernetes namespace the runner pod is deployed in.")
+	rootCmd.PersistentFlags().String("runner-deployment", "runner", "The kubernetes namespace the runner pod is deployed in.")
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT")
@@ -57,7 +61,8 @@ func init() {
 	viper.BindEnv("pod-max-wait", "OPSLEVEL_POD_MAX_WAIT")
 	viper.BindEnv("job-pod-max-lifetime", "OPSLEVEL_JOB_POD_MAX_LIFETIME")
 	viper.BindEnv("pod-namespace", "OPSLEVEL_POD_NAMESPACE")
-	viper.BindEnv("pod-name", "POD_NAME")
+	viper.BindEnv("runner-pod-namespace", "RUNNER_POD_NAMESPACE")
+	viper.BindEnv("runner-pod-name", "RUNNER_POD_NAME")
 	viper.BindEnv("pod-shell", "OPSLEVEL_POD_SHELL")
 	viper.BindEnv("pod-log-max-interval", "OPSLEVEL_POD_LOG_MAX_INTERVAL")
 	viper.BindEnv("pod-log-max-size", "OPSLEVEL_POD_LOG_MAX_SIZE")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -50,8 +50,8 @@ func init() {
 	rootCmd.PersistentFlags().Int("pod-log-max-interval", 30, "The max amount of time between when pod logs are shipped to OpsLevel. Works in tandem with 'pod-log-max-size'")
 	rootCmd.PersistentFlags().Int("pod-log-max-size", 1000000, "The max amount in bytes to buffer before pod logs are shipped to OpsLevel. Works in tandem with 'pod-log-max-interval'")
 	rootCmd.PersistentFlags().String("runner-pod-name", "", "overrides environment variable 'RUNNER_POD_NAME'")
-	rootCmd.PersistentFlags().String("runner-pod-namespace", "default", "The kubernetes namespace the runner pod is deployed in.")
-	rootCmd.PersistentFlags().String("runner-deployment", "runner", "The kubernetes namespace the runner pod is deployed in.")
+	rootCmd.PersistentFlags().String("runner-pod-namespace", "default", "The kubernetes namespace the runner pod is deployed in. Overrides environment variable 'RUNNER_POD_NAMESPACE'")
+	rootCmd.PersistentFlags().String("runner-deployment", "runner", "The runner's kubernetes deployment name")
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.PersistentFlags().String("api-token", "", "The OpsLevel API Token. Overrides environment variable 'OPSLEVEL_API_TOKEN'")
 	rootCmd.PersistentFlags().String("log-format", "TEXT", "overrides environment variable 'OPSLEVEL_LOG_FORMAT' (options [\"JSON\", \"TEXT\"])")
 	rootCmd.PersistentFlags().String("log-level", "INFO", "overrides environment variable 'OPSLEVEL_LOG_LEVEL' (options [\"ERROR\", \"WARN\", \"INFO\", \"DEBUG\"])")
+	rootCmd.PersistentFlags().Bool("scaling-enabled", false, "Enables built-in pod scaling for kubernetes environment, defaults to false for local development")
 
 	rootCmd.PersistentFlags().Int("pod-max-wait", 60, "The max amount of time to wait for the job pod to become healthy.")
 	rootCmd.PersistentFlags().Int("job-pod-max-lifetime", 3600, "The max amount of time a job pod can run for.")
@@ -59,6 +60,7 @@ func init() {
 	viper.BindEnv("pod-shell", "OPSLEVEL_POD_SHELL")
 	viper.BindEnv("pod-log-max-interval", "OPSLEVEL_POD_LOG_MAX_INTERVAL")
 	viper.BindEnv("pod-log-max-size", "OPSLEVEL_POD_LOG_MAX_SIZE")
+	viper.BindEnv("scaling-enabled", "SCALING_ENABLED")
 	cobra.OnInitialize(initConfig)
 }
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -57,6 +57,7 @@ func init() {
 	viper.BindEnv("pod-max-wait", "OPSLEVEL_POD_MAX_WAIT")
 	viper.BindEnv("job-pod-max-lifetime", "OPSLEVEL_JOB_POD_MAX_LIFETIME")
 	viper.BindEnv("pod-namespace", "OPSLEVEL_POD_NAMESPACE")
+	viper.BindEnv("pod-name", "POD_NAME")
 	viper.BindEnv("pod-shell", "OPSLEVEL_POD_SHELL")
 	viper.BindEnv("pod-log-max-interval", "OPSLEVEL_POD_LOG_MAX_INTERVAL")
 	viper.BindEnv("pod-log-max-size", "OPSLEVEL_POD_LOG_MAX_SIZE")

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -9,8 +9,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"os"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,10 @@ import (
 var runCmd = &cobra.Command{
 	Use: "run",
 	Run: doRun,
+}
+
+type k8sClientset struct {
+	client *clientset.Clientset
 }
 
 func init() {
@@ -67,7 +72,7 @@ func doRun(cmd *cobra.Command, args []string) {
 func electLeader() {
 	leaseLockName := "opslevel-runner-leader-lock"
 	leaseLockNamespace := viper.GetString("pod-namespace")
-	podName := os.Getenv("POD_NAME")
+	podName := viper.GetString("pod-name")
 
 	config, err := pkg.GetKubernetesConfig()
 
@@ -75,13 +80,28 @@ func electLeader() {
 		log.Info().Msgf("Failed to get kubeconfig")
 	}
 
-	clientset.NewForConfigOrDie(config)
+	client := k8sClientset{
+		client: clientset.NewForConfigOrDie(config),
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	lock := pkg.GetNewLock(leaseLockName, podName, leaseLockNamespace)
+	lock := client.getNewLock(leaseLockName, podName, leaseLockNamespace)
 	pkg.RunLeaderElection(lock, ctx, podName)
+}
+
+func (c k8sClientset) getNewLock(lockname, podname, namespace string) *resourcelock.LeaseLock {
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      lockname,
+			Namespace: namespace,
+		},
+		Client: c.client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: podname,
+		},
+	}
 }
 
 func startWorkers(runnerId string, stop <-chan struct{}) *sync.WaitGroup {

--- a/src/pkg/leaderElection.go
+++ b/src/pkg/leaderElection.go
@@ -1,0 +1,78 @@
+package pkg
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+var (
+	client   *clientset.Clientset
+	isLeader bool
+)
+
+func GetNewLock(lockname, podname, namespace string) *resourcelock.LeaseLock {
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      lockname,
+			Namespace: namespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: podname,
+		},
+	}
+}
+
+func RunLeaderElection(lock *resourcelock.LeaseLock, ctx context.Context, id string) {
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(c context.Context) {
+				isLeader = true
+				klog.Info("Perform Migration")
+				for {
+					klog.Info("doing stuff...")
+					time.Sleep(5 * time.Second)
+				}
+			},
+			OnStoppedLeading: func() {
+				isLeader = false
+				for {
+					klog.Info("no longer the leader, staging inactive.")
+					time.Sleep(5 * time.Second)
+				}
+			},
+			OnNewLeader: func(current_id string) {
+				if !isLeader && current_id == id {
+					klog.Info("started leading!")
+					return
+				}
+				for {
+					klog.Info("leader is %s", current_id)
+					time.Sleep(5 * time.Second)
+				}
+			},
+		},
+	})
+}
+
+func GetKubernetesConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}


### PR DESCRIPTION
I've tested and confirmed that this elect a leader initially and also elects a new leader when current leader is terminated:
```
$ OPSLEVEL_API_TOKEN=<admin token> OPSLEVEL_API_URL=<OpsLevel API URL> SCALING_ENABLED=true go run main.go run --pod-name=runner-local-new-13
3:57AM INF Runner Version: -
3:57AM INF electing leader...
I1109 21:57:30.361667   84812 leaderelection.go:248] attempting to acquire leader lease default/opslevel-runner-leader-lock...
3:57AM INF leader is runner-local-new-11
I1109 21:58:46.149562   84812 leaderelection.go:258] successfully acquired lease default/opslevel-runner-leader-lock
3:58AM INF runner-local-new-13 started leading!
3:58AM INF Perform Migration
3:58AM INF leader is runner-local-new-13
3:58AM INF Getting replica count...
```