### PR TITLE
bump go module version, add minor lint fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
       - name: Cache Go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
       - name: Run Tests
         run: |-
           cd src/

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/getsentry/sentry-go"
 	opslevel_common "github.com/opslevel/opslevel-common/v2022"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	clientset "k8s.io/client-go/kubernetes"
-	"strings"
-	"sync"
-	"time"
 
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/opslevel/opslevel-runner/pkg"
@@ -137,7 +138,7 @@ func jobWorker(wg *sync.WaitGroup, index int, runnerId opslevel.ID, jobQueue <-c
 			trace.WithAttributes(attribute.String("job", jobNumber)),
 		)
 		outcome := runner.Run(job, streamer.Stdout, streamer.Stderr)
-		ctx, spanFinish := tracer.Start(ctx,
+		_, spanFinish := tracer.Start(ctx,
 			"finish-job",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(attribute.String("job", jobNumber)))

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/opslevel/opslevel-runner
 
-go 1.19
+go 1.20
 
 require (
 	github.com/getsentry/sentry-go v0.21.0

--- a/src/pkg/opslevelAppendLogProcessor.go
+++ b/src/pkg/opslevelAppendLogProcessor.go
@@ -2,9 +2,10 @@ package pkg
 
 import (
 	"encoding/base64"
+	"time"
+
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog"
-	"time"
 )
 
 type OpsLevelAppendLogProcessor struct {
@@ -49,7 +50,7 @@ func (s *OpsLevelAppendLogProcessor) Process(line string) string {
 
 	s.logLinesBytesSize += lineBytesSize
 	s.logLines = append(s.logLines, base64.StdEncoding.EncodeToString(lineInBytes))
-	if s.firstLine == false {
+	if !s.firstLine {
 		s.logger.Trace().Msg("Shipping logs because its the first line ...")
 		s.firstLine = true
 		s.submit()


### PR DESCRIPTION
Bump go version to `1.20` since `1.19` is EOL'd.

Added a few fixes found by linter - but waiting to add Taskfile for later PR