### PR TITLE
Fix goreleaser warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.1.0
         with:
-          args: release --rm-dist --release-notes=../.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md
+          args: release --clean --release-notes=../.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md
           workdir: ./src
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -35,12 +35,12 @@ brews:
     homepage: "https://www.opslevel.com/"
     description: "Command line tool that runs jobs for OpsLevel"
     license: "MIT"
-    folder: Formula
+    directory: Formula
     install: |
       bin.install "opslevel-runner"
     test: |
       system "#{bin}/opslevel-runner version"
-    tap:
+    repository:
       owner: opslevel
       name: homebrew-tap
       token: "{{ .Env.ORG_GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes

• DEPRECATED: --rm-dist was deprecated in favor of --clean,
• DEPRECATED: brews.folder should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
• DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info

