### PR TITLE
Add 2 new metrics and beef up log lines

### DIFF
--- a/src/pkg/faktoryRunnerAppendJobLogProcessor.go
+++ b/src/pkg/faktoryRunnerAppendJobLogProcessor.go
@@ -100,12 +100,14 @@ func (s *FaktoryAppendJobLogProcessor) submit() {
 				return b.Push(job)
 			})
 			if err != nil {
-				s.logger.Error().Err(err).Msgf("error while appending '%d' log line(s) for job", len(s.logLines))
+				MetricEnqueueBatchFailed.Inc()
+				s.logger.Error().Err(err).Msgf("error while enqueuing append logs for '%d' log line(s) for job '%d'", len(s.logLines), s.jobId)
 			}
 		} else {
 			err := s.client.Push(job)
 			if err != nil {
-				s.logger.Error().Err(err).Msgf("error while appending '%d' log line(s) for job", len(s.logLines))
+				MetricEnqueueFailed.Inc()
+				s.logger.Error().Err(err).Msgf("error while enqueuing append logs for '%d' log line(s) for job '%s'", len(s.logLines), s.jobId)
 			}
 		}
 	}

--- a/src/pkg/faktoryRunnerAppendJobLogProcessor.go
+++ b/src/pkg/faktoryRunnerAppendJobLogProcessor.go
@@ -101,7 +101,7 @@ func (s *FaktoryAppendJobLogProcessor) submit() {
 			})
 			if err != nil {
 				MetricEnqueueBatchFailed.Inc()
-				s.logger.Error().Err(err).Msgf("error while enqueuing append logs for '%d' log line(s) for job '%d'", len(s.logLines), s.jobId)
+				s.logger.Error().Err(err).Msgf("error while enqueuing append logs for '%d' log line(s) for job '%s'", len(s.logLines), s.jobId)
 			}
 		} else {
 			err := s.client.Push(job)

--- a/src/pkg/faktorySetOutcomeProcessor.go
+++ b/src/pkg/faktorySetOutcomeProcessor.go
@@ -95,12 +95,14 @@ func (s *FaktorySetOutcomeProcessor) Flush(outcome JobOutcome) {
 			return b.Push(job)
 		})
 		if err != nil {
-			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job", outcome.Outcome)
+			MetricEnqueueBatchFailed.Inc()
+			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%d'", outcome.Outcome, s.jobId)
 		}
 	} else {
 		err := s.client.Push(job)
 		if err != nil {
-			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job", outcome.Outcome)
+			MetricEnqueueFailed.Inc()
+			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%d'", outcome.Outcome, s.jobId)
 		}
 	}
 }

--- a/src/pkg/faktorySetOutcomeProcessor.go
+++ b/src/pkg/faktorySetOutcomeProcessor.go
@@ -96,13 +96,13 @@ func (s *FaktorySetOutcomeProcessor) Flush(outcome JobOutcome) {
 		})
 		if err != nil {
 			MetricEnqueueBatchFailed.Inc()
-			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%d'", outcome.Outcome, s.jobId)
+			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%s'", outcome.Outcome, s.jobId)
 		}
 	} else {
 		err := s.client.Push(job)
 		if err != nil {
 			MetricEnqueueFailed.Inc()
-			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%d'", outcome.Outcome, s.jobId)
+			s.logger.Error().Err(err).Msgf("error when reporting outcome '%s' for job '%s'", outcome.Outcome, s.jobId)
 		}
 	}
 }

--- a/src/pkg/metrics.go
+++ b/src/pkg/metrics.go
@@ -13,11 +13,13 @@ import (
 )
 
 var (
-	metricNamespace      = "opslevel_runner"
-	MetricJobsStarted    prometheus.Counter
-	MetricJobsDuration   prometheus.Histogram
-	MetricJobsFinished   *prometheus.CounterVec
-	MetricJobsProcessing prometheus.Gauge
+	metricNamespace          = "opslevel_runner"
+	MetricJobsStarted        prometheus.Counter
+	MetricJobsDuration       prometheus.Histogram
+	MetricJobsFinished       *prometheus.CounterVec
+	MetricJobsProcessing     prometheus.Gauge
+	MetricEnqueueFailed      prometheus.Counter
+	MetricEnqueueBatchFailed prometheus.Counter
 )
 
 func initMetrics(id string) {
@@ -45,6 +47,18 @@ func initMetrics(id string) {
 		Namespace:   metricNamespace,
 		Name:        "jobs_processing",
 		Help:        "The current number of active jobs being processed.",
+		ConstLabels: prometheus.Labels{"runner": id},
+	})
+	MetricEnqueueFailed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace:   metricNamespace,
+		Name:        "jobs_enqueue_failed",
+		Help:        "The count of jobs that failed to enqueue to faktory.",
+		ConstLabels: prometheus.Labels{"runner": id},
+	})
+	MetricEnqueueBatchFailed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace:   metricNamespace,
+		Name:        "jobs_enqueue_batch_failed",
+		Help:        "The count of jobs that failed to enqueue to faktory for a batch.",
 		ConstLabels: prometheus.Labels{"runner": id},
 	})
 }


### PR DESCRIPTION
## Issues

We are seeing sporadic log lines of

```
runner-faktory-6c7668cb4d-95rsq runner-faktory 11:41PM ERR error when reporting outcome 'failed' for job error="ERR No such batch b-qC_-3KNyyZft5A" runner=faktory
runner-faktory-6c7668cb4d-n8vck runner-faktory 2:44PM ERR error when reporting outcome 'failed' for job error="ERR No such batch b-IROXFWRY5r8IUQ" runner=faktory
runner-faktory-6c7668cb4d-95rsq runner-faktory 3:55PM ERR error when reporting outcome 'failed' for job error="ERR No such batch b-ofweIgoJiByTTQ" runner=faktory
```

So this adds metrics to see when and how often they are happening along with adding the job ID to the log line for further debugging.
