### PR TITLE
Update Dockerfile path in goreleaser

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -24,7 +24,8 @@ builds:
 archives:
   - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
 dockers_v2:
-  - images:
+  - dockerfile: ../Dockerfile
+    images:
     - "public.ecr.aws/opslevel/opslevel-runner"
     tags:
     - "latest"


### PR DESCRIPTION
One-liner: We moved the Dockerfile up to root but missed updating `.goreleaser.yml`, which was implicitly relying on Dockerfile being in its working directory