### PR TITLE
Fix job pod memory limit multiplier typo (1204 -> 1024)

### DIFF
--- a/src/pkg/k8s.go
+++ b/src/pkg/k8s.go
@@ -218,7 +218,7 @@ func (s *JobRunner) getPodObject(identifier string, labels map[string]string, jo
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    *resource.NewMilliQuantity(s.jobPodConfig.CpuLimit, resource.DecimalSI),
-							corev1.ResourceMemory: *resource.NewQuantity(s.jobPodConfig.MemLimit*1024*1204, resource.BinarySI),
+							corev1.ResourceMemory: *resource.NewQuantity(s.jobPodConfig.MemLimit*1024*1024, resource.BinarySI),
 						},
 					},
 					Env: s.getPodEnv(job.Variables),


### PR DESCRIPTION
## What

The job pod memory limit was computed as `MemLimit*1024*1204` instead of `MemLimit*1024*1024` — a digit-swap typo that inflates every job pod's effective memory limit by ~17.6% over the configured value. For example, prod's `--job-pod-limits-memory=6656` currently produces a ~7.8 GiB limit instead of the intended 6.5 GiB.

## ⚠️ Behavior change

This *lowers* effective job pod memory limits for all existing deployments back to their configured values. Any job that has been relying on the accidental headroom may start getting OOMKilled after this rolls out. If we'd rather keep current effective limits, the configured MB values should be bumped ~17.6% in the same release.

Heads up: #308 refactors these lines into a `resources()` helper (deliberately preserving this bug) — whichever lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)