### PR TITLE
Emit account_id and job metadata as Kubernetes pod labels

### DIFF
--- a/.changes/unreleased/Feature-20260717-000000.yaml
+++ b/.changes/unreleased/Feature-20260717-000000.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Emit account/job metadata as Kubernetes pod labels (`opslevel.com/account-id`, `opslevel.com/job-id`, `opslevel.com/mode`, `opslevel.com/job-type`, plus a short-form `accountID`) so job pods can be filtered by account/job/mode without parsing the pod name
+time: 2026-07-17T00:00:00.000000Z

--- a/src/pkg/k8s.go
+++ b/src/pkg/k8s.go
@@ -386,16 +386,31 @@ func (s *JobRunner) Run(ctx context.Context, job opslevel.RunnerJob, stdout, std
 	// running pods can be filtered by account/job/mode without parsing the pod
 	// name. Added after building the selector so they stay out of the PDB
 	// selector, which the instance label already makes unique.
+	//
+	// Each label is stamped in both its prefixed long form (stable, ideal for
+	// DataDog podLabelsAsTags) and a short form for terse CLI filtering
+	// (e.g. `kubectl get pods -l accountID=XXX`).
+
+	// app.kubernetes.io/name is the well-known Kubernetes label for the name of
+	// the application; every job pod is an instance of "opslevel-job".
 	labels["app.kubernetes.io/name"] = "opslevel-job"
-	labels["opslevel.com/job-id"] = id
+	// mode is the runner backend the job came from: "api" or "faktory".
 	labels["opslevel.com/mode"] = viper.GetString("mode")
+	labels["mode"] = viper.GetString("mode")
+	// job-id is the OpsLevel job identifier (one value per job).
+	labels["opslevel.com/job-id"] = id
+	labels["jobID"] = id
 	// Variable keys arrive uppercased/sanitized by the OpsLevel API (see
 	// RunnerJobType#format_key_as_valid_env_var_name), so match the uppercase key.
 	if accountId := getRunnerJobVariable(job.Variables, "ACCOUNT_ID"); accountId != "" {
+		// account-id is the OpsLevel account the job belongs to.
 		labels["opslevel.com/account-id"] = accountId
+		labels["accountID"] = accountId
 	}
 	if jobType := getRunnerJobVariable(job.Variables, "JOB_TYPE"); jobType != "" {
+		// job-type is the job's kind / template slug (e.g. "repo_grep_v1").
 		labels["opslevel.com/job-type"] = jobType
+		labels["jobType"] = jobType
 	}
 	// TODO: manage pods based on image for re-use?
 	cfgMap, err := s.CreateConfigMap(ctx, s.getConfigMapObject(identifier, job))

--- a/src/pkg/k8s.go
+++ b/src/pkg/k8s.go
@@ -111,6 +111,16 @@ func NewJobRunner(runnerId string, path string) *JobRunner {
 	}
 }
 
+// getRunnerJobVariable returns the value of the job variable with the given key, if present.
+func getRunnerJobVariable(configs []opslevel.RunnerJobVariable, key string) string {
+	for _, config := range configs {
+		if config.Key == key {
+			return config.Value
+		}
+	}
+	return ""
+}
+
 // getPodEnv returns the env vars to inject into a container for the given
 // scope. Variables with no Scope set are visible to every container; variables
 // with a Scope are only visible to containers running in that scope.
@@ -371,6 +381,16 @@ func (s *JobRunner) Run(ctx context.Context, job opslevel.RunnerJob, stdout, std
 			Message: fmt.Sprintf("failed to create label selector REASON: %s", err),
 			Outcome: opslevel.RunnerJobOutcomeEnumFailed,
 		}
+	}
+	// Descriptive labels for observability (e.g. DataDog podLabelsAsTags), so
+	// running pods can be filtered by account/job/mode without parsing the pod
+	// name. Added after building the selector so they stay out of the PDB
+	// selector, which the instance label already makes unique.
+	labels["app.kubernetes.io/name"] = "opslevel-job"
+	labels["opslevel.com/job-id"] = id
+	labels["opslevel.com/mode"] = viper.GetString("mode")
+	if accountId := getRunnerJobVariable(job.Variables, "account_id"); accountId != "" {
+		labels["opslevel.com/account-id"] = accountId
 	}
 	// TODO: manage pods based on image for re-use?
 	cfgMap, err := s.CreateConfigMap(ctx, s.getConfigMapObject(identifier, job))

--- a/src/pkg/k8s.go
+++ b/src/pkg/k8s.go
@@ -389,8 +389,13 @@ func (s *JobRunner) Run(ctx context.Context, job opslevel.RunnerJob, stdout, std
 	labels["app.kubernetes.io/name"] = "opslevel-job"
 	labels["opslevel.com/job-id"] = id
 	labels["opslevel.com/mode"] = viper.GetString("mode")
-	if accountId := getRunnerJobVariable(job.Variables, "account_id"); accountId != "" {
+	// Variable keys arrive uppercased/sanitized by the OpsLevel API (see
+	// RunnerJobType#format_key_as_valid_env_var_name), so match the uppercase key.
+	if accountId := getRunnerJobVariable(job.Variables, "ACCOUNT_ID"); accountId != "" {
 		labels["opslevel.com/account-id"] = accountId
+	}
+	if jobType := getRunnerJobVariable(job.Variables, "JOB_TYPE"); jobType != "" {
+		labels["opslevel.com/job-type"] = jobType
 	}
 	// TODO: manage pods based on image for re-use?
 	cfgMap, err := s.CreateConfigMap(ctx, s.getConfigMapObject(identifier, job))

--- a/src/pkg/k8s_test.go
+++ b/src/pkg/k8s_test.go
@@ -193,6 +193,33 @@ func TestGetPodEnv_FiltersByScope(t *testing.T) {
 	autopilot.Equals(t, []string{"BOTH", "MAIN_ONLY"}, mainKeys)
 }
 
+func TestGetRunnerJobVariable_ReturnsMatchingValue(t *testing.T) {
+	// Arrange
+	vars := []opslevel.RunnerJobVariable{
+		{Key: "FOO", Value: "bar"},
+		{Key: "account_id", Value: "acct-123"},
+	}
+
+	// Act
+	value := getRunnerJobVariable(vars, "account_id")
+
+	// Assert
+	autopilot.Equals(t, "acct-123", value)
+}
+
+func TestGetRunnerJobVariable_ReturnsEmptyWhenMissing(t *testing.T) {
+	// Arrange
+	vars := []opslevel.RunnerJobVariable{
+		{Key: "FOO", Value: "bar"},
+	}
+
+	// Act
+	value := getRunnerJobVariable(vars, "account_id")
+
+	// Assert
+	autopilot.Equals(t, "", value)
+}
+
 func TestGetPodObject_NoInitCommands(t *testing.T) {
 	// Arrange
 	runner := &JobRunner{

--- a/src/pkg/k8s_test.go
+++ b/src/pkg/k8s_test.go
@@ -195,13 +195,15 @@ func TestGetPodEnv_FiltersByScope(t *testing.T) {
 
 func TestGetRunnerJobVariable_ReturnsMatchingValue(t *testing.T) {
 	// Arrange
+	// The OpsLevel API uppercases/sanitizes variable keys before sending them,
+	// so the runner matches the uppercase key.
 	vars := []opslevel.RunnerJobVariable{
 		{Key: "FOO", Value: "bar"},
-		{Key: "account_id", Value: "acct-123"},
+		{Key: "ACCOUNT_ID", Value: "acct-123"},
 	}
 
 	// Act
-	value := getRunnerJobVariable(vars, "account_id")
+	value := getRunnerJobVariable(vars, "ACCOUNT_ID")
 
 	// Assert
 	autopilot.Equals(t, "acct-123", value)
@@ -211,6 +213,21 @@ func TestGetRunnerJobVariable_ReturnsEmptyWhenMissing(t *testing.T) {
 	// Arrange
 	vars := []opslevel.RunnerJobVariable{
 		{Key: "FOO", Value: "bar"},
+	}
+
+	// Act
+	value := getRunnerJobVariable(vars, "ACCOUNT_ID")
+
+	// Assert
+	autopilot.Equals(t, "", value)
+}
+
+func TestGetRunnerJobVariable_IsCaseSensitive(t *testing.T) {
+	// Arrange
+	// Guards the bug where the runner looked up "account_id" but the API sends
+	// "ACCOUNT_ID"; the lowercase key must NOT match.
+	vars := []opslevel.RunnerJobVariable{
+		{Key: "ACCOUNT_ID", Value: "acct-123"},
 	}
 
 	// Act


### PR DESCRIPTION
## Summary
Emit account/job metadata as Kubernetes **pod labels** rather than weaving it
into the pod name (which risks the 63-char limit and OpsLevel-side naming
conventions). This enables native DataDog filtering via `podLabelsAsTags` with
no pod-name parsing. The pod/ConfigMap/PDB name is unchanged.

Labels stamped on each job pod:

| label | value | cardinality |
|---|---|---|
| `app.kubernetes.io/name` | `opslevel-job` | 1 |
| `opslevel.com/mode` | `faktory` \| `api` | 2 |
| `opslevel.com/account-id` | account id (when set) | bounded by # accounts |
| `opslevel.com/job-id` | job id | unbounded — see note |
| `opslevel.com/job-type` | job kind / template slug (when set) | ~13 |

Labels are added *after* building the PDB label selector so they stay out of the
selector, which the `app.kubernetes.io/instance` label already makes unique.

Also adds a `getRunnerJobVariable` helper (named explicitly since a similar
helper is anticipated for egress proxies).

## Fixes
- **`ACCOUNT_ID` lookup:** the OpsLevel API uppercases/sanitizes variable keys
  before sending them (`RunnerJobType#format_key_as_valid_env_var_name`), so the
  account id arrives as `ACCOUNT_ID`, not `account_id`. The original lookup used
  the lowercase key and never matched, leaving the label always empty. Now
  matches the uppercase key.

## Requires a companion OpsLevel change
`opslevel.com/job-type` is a **no-op until the OpsLevel API emits a `JOB_TYPE`
variable.** The job's kind is its template (`Runners::JobRun#template_name`,
~13 values) and is currently only carried by the DB `template_id` column — it is
never sent to the runner. To light up the label, add a derived variable in
`app/models/runners/job_run.rb#derived_variables` (alongside `JOB_ID` /
`ACCOUNT_ID`):

```ruby
{ "key" => "JOB_TYPE", "value" => template_name.demodulize.underscore, "sensitive" => false },
# e.g. "Runners::RepoGrepV1" -> "repo_grep_v1"
```

Sending a clean slug from the server keeps the label value valid (raw
`template_name` contains `::`, which is invalid in a k8s label value) and
low-cardinality.

> **Cardinality note:** `opslevel.com/job-id` is unbounded (one value per job).
> It's fine as a k8s label (`kubectl` filtering) and as a DataDog *log*
> attribute, but should **not** be mapped into `podLabelsAsTags` as a *metric*
> tag. `job-type` is the opposite — low cardinality and ideal for tagging.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg` passes
- [x] `TestGetRunnerJobVariable_*` cover the helper, including a case-sensitivity
      guard for the `ACCOUNT_ID` bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
