### PR TITLE
fix: check error before using config in GetKubernetesConfig

### DIFF
--- a/src/pkg/k8s.go
+++ b/src/pkg/k8s.go
@@ -439,12 +439,12 @@ func GetKubernetesConfig() (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
-	config.QPS = float32(viper.GetInt("k8s-api-qps"))
-	config.Burst = viper.GetInt("k8s-api-burst")
-	config.Timeout = time.Second * time.Duration(viper.GetInt("job-pod-exec-max-wait"))
 	if err != nil {
 		return nil, err
 	}
+	config.QPS = float32(viper.GetInt("k8s-api-qps"))
+	config.Burst = viper.GetInt("k8s-api-burst")
+	config.Timeout = time.Second * time.Duration(viper.GetInt("job-pod-exec-max-wait"))
 	return config, nil
 }
 


### PR DESCRIPTION
## Problem

In `GetKubernetesConfig` (src/pkg/k8s.go), `config.QPS`, `config.Burst`, and `config.Timeout` were assigned **before** the error check on `ClientConfig()`. When loading the kubeconfig fails (missing kubeconfig, invalid context, etc.), `config` is nil and the runner panics with a nil-pointer dereference instead of surfacing the actual error. This affects both the shared client bootstrap (`GetSharedK8sClient`) and `RunLeaderElection`, which call this function.

## Fix

Move the field assignments below the error check so the load error is returned to the caller.

## Testing

- `go build ./...` and `go test ./pkg/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)