### PR TITLE
fix: ship buffered job logs on interval even when output is idle

### DIFF
--- a/src/pkg/faktoryRunnerAppendJobLogProcessor.go
+++ b/src/pkg/faktoryRunnerAppendJobLogProcessor.go
@@ -19,8 +19,7 @@ type FaktoryAppendJobLogProcessor struct {
 	logLines          []string
 	logLinesBytesSize int
 	firstLine         bool
-	lastTime          time.Time
-	elapsed           time.Duration
+	lastSubmitTime    time.Time
 }
 
 func NewFaktoryAppendJobLogProcessor(helper faktoryWorker.Helper, logger zerolog.Logger, jobId opslevel.ID, maxBytes int, maxTime time.Duration) *FaktoryAppendJobLogProcessor {
@@ -33,7 +32,7 @@ func NewFaktoryAppendJobLogProcessor(helper faktoryWorker.Helper, logger zerolog
 		logLines:          []string{},
 		logLinesBytesSize: 0,
 		firstLine:         false,
-		lastTime:          time.Now(),
+		lastSubmitTime:    time.Now(),
 	}
 }
 
@@ -54,15 +53,16 @@ func (s *FaktoryAppendJobLogProcessor) Process(line string) string {
 		s.submit()
 	}
 
-	s.elapsed += time.Since(s.lastTime)
-	if s.elapsed > s.maxTime {
+	return line
+}
+
+// Tick ships buffered logs once maxTime has elapsed since the last submit,
+// so a job that goes quiet still has its logs delivered on schedule.
+func (s *FaktoryAppendJobLogProcessor) Tick() {
+	if len(s.logLines) > 0 && time.Since(s.lastSubmitTime) > s.maxTime {
 		s.logger.Trace().Msg("Shipping logs because of maxTime ...")
-		s.elapsed = time.Since(time.Now())
 		s.submit()
 	}
-	s.lastTime = time.Now()
-
-	return line
 }
 
 func (s *FaktoryAppendJobLogProcessor) ProcessStdout(line string) string {
@@ -111,6 +111,6 @@ func (s *FaktoryAppendJobLogProcessor) submit() {
 		}
 	}
 	s.logLinesBytesSize = 0
-	s.logLines = nil
 	s.logLines = []string{}
+	s.lastSubmitTime = time.Now()
 }

--- a/src/pkg/logs.go
+++ b/src/pkg/logs.go
@@ -15,6 +15,13 @@ type LogProcessor interface {
 	Flush(outcome JobOutcome)
 }
 
+// tickable is optionally implemented by processors that need to do periodic
+// work even when no new lines arrive (e.g. time-based log shipping). Tick is
+// called from the streamer's Run loop on every ticker interval.
+type tickable interface {
+	Tick()
+}
+
 type LogStreamer struct {
 	Stdout     *SafeBuffer
 	Stderr     *SafeBuffer
@@ -91,6 +98,11 @@ func (s *LogStreamer) Run(ctx context.Context) {
 			for _, stream := range s.streams() {
 				for strings.Contains(stream.buf.String(), "\n") {
 					s.processLine(stream)
+				}
+			}
+			for _, processor := range s.processors {
+				if t, ok := processor.(tickable); ok {
+					t.Tick()
 				}
 			}
 		}

--- a/src/pkg/logs_test.go
+++ b/src/pkg/logs_test.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +25,29 @@ func (c *captureProcessor) ProcessStderr(line string) string {
 }
 
 func (c *captureProcessor) Flush(_ JobOutcome) {}
+
+type tickCountProcessor struct {
+	captureProcessor
+	ticks atomic.Int32
+}
+
+func (c *tickCountProcessor) Tick() {
+	c.ticks.Add(1)
+}
+
+func TestLogStreamerCallsTickWhileIdle(t *testing.T) {
+	proc := &tickCountProcessor{}
+	s := NewLogStreamer(zerolog.Nop(), proc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.Run(ctx)
+
+	// No lines are ever written; the streamer should still tick processors.
+	time.Sleep(200 * time.Millisecond)
+
+	autopilot.Assert(t, proc.ticks.Load() > 0, "expected Tick to be called while idle")
+}
 
 func TestLogStreamerPartialLineStdout(t *testing.T) {
 	cap := &captureProcessor{}

--- a/src/pkg/opslevelAppendLogProcessor.go
+++ b/src/pkg/opslevelAppendLogProcessor.go
@@ -19,8 +19,7 @@ type OpsLevelAppendLogProcessor struct {
 	logLines          []string
 	logLinesBytesSize int
 	firstLine         bool
-	lastTime          time.Time
-	elapsed           time.Duration
+	lastSubmitTime    time.Time
 }
 
 func NewOpsLevelAppendLogProcessor(client *opslevel.Client, logger zerolog.Logger, runnerId opslevel.ID, jobId opslevel.ID, jobNumber string, maxBytes int, maxTime time.Duration) *OpsLevelAppendLogProcessor {
@@ -35,7 +34,7 @@ func NewOpsLevelAppendLogProcessor(client *opslevel.Client, logger zerolog.Logge
 		logLines:          []string{},
 		logLinesBytesSize: 0,
 		firstLine:         false,
-		lastTime:          time.Now(),
+		lastSubmitTime:    time.Now(),
 	}
 }
 
@@ -56,15 +55,16 @@ func (s *OpsLevelAppendLogProcessor) Process(line string) string {
 		s.submit()
 	}
 
-	s.elapsed += time.Since(s.lastTime)
-	if s.elapsed > s.maxTime {
+	return line
+}
+
+// Tick ships buffered logs once maxTime has elapsed since the last submit,
+// so a job that goes quiet still has its logs delivered on schedule.
+func (s *OpsLevelAppendLogProcessor) Tick() {
+	if len(s.logLines) > 0 && time.Since(s.lastSubmitTime) > s.maxTime {
 		s.logger.Trace().Msg("Shipping logs because of maxTime ...")
-		s.elapsed = 0
 		s.submit()
 	}
-	s.lastTime = time.Now()
-
-	return line
 }
 
 func (s *OpsLevelAppendLogProcessor) ProcessStdout(line string) string {
@@ -98,4 +98,5 @@ func (s *OpsLevelAppendLogProcessor) submit() {
 	}
 	s.logLinesBytesSize = 0
 	s.logLines = s.logLines[:0]
+	s.lastSubmitTime = time.Now()
 }

--- a/src/pkg/opslevelAppendLogProcessor_test.go
+++ b/src/pkg/opslevelAppendLogProcessor_test.go
@@ -1,0 +1,24 @@
+package pkg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rocktavious/autopilot/v2023"
+	"github.com/rs/zerolog"
+)
+
+func TestOpsLevelAppendLogProcessorTickShipsIdleLogs(t *testing.T) {
+	// Arrange
+	p := NewOpsLevelAppendLogProcessor(nil, zerolog.Nop(), "1", "1", "1", 1024, 50*time.Millisecond)
+	p.Process("first")  // first line ships immediately
+	p.Process("second") // buffered
+	autopilot.Equals(t, 1, len(p.logLines))
+	// Act & Assert: maxTime has not elapsed yet, so nothing ships
+	p.Tick()
+	autopilot.Equals(t, 1, len(p.logLines))
+	// Act & Assert: once maxTime elapses, Tick ships without any new lines
+	time.Sleep(100 * time.Millisecond)
+	p.Tick()
+	autopilot.Equals(t, 0, len(p.logLines))
+}


### PR DESCRIPTION
## Problem

`job-pod-log-max-interval` promises logs are shipped to OpsLevel at most N seconds apart, but the max-time check lived inside `Process`, which only runs when a **new line arrives**. A job that prints a burst of output and then goes quiet (e.g. a long compile or terraform apply) has those buffered logs held until the next line, the maxBytes threshold, or job completion — potentially the entire job duration.

## Fix

- `LogStreamer.Run` now calls an optional `Tick()` (new `tickable` interface, asserted per processor) on every ticker interval, so processors get a periodic hook even with no output. `Tick` runs on the same goroutine as `Process`, so no new synchronization is needed.
- Both `OpsLevelAppendLogProcessor` and `FaktoryAppendJobLogProcessor` implement `Tick`: if the buffer is non-empty and `maxTime` has elapsed since the last submit, they ship.
- This replaces the arrival-driven `elapsed`/`lastTime` accounting with a single `lastSubmitTime`, and incidentally removes the `s.elapsed = time.Since(time.Now())` typo in the Faktory processor (which assigned a tiny negative duration instead of resetting to zero).

## Testing

- `TestOpsLevelAppendLogProcessorTickShipsIdleLogs` — buffered lines ship via `Tick` after `maxTime` with no new output, and not before.
- `TestLogStreamerCallsTickWhileIdle` — the streamer ticks processors even when no lines are ever written.
- `go test -race ./pkg/...` passes.

Note: touches `logs.go` alongside #313, so whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)